### PR TITLE
fixed arguments keys on MultipleGet Command

### DIFF
--- a/src/ReJSON/Command/MultipleGet.php
+++ b/src/ReJSON/Command/MultipleGet.php
@@ -29,7 +29,7 @@ final class MultipleGet extends CommandAbstract implements CommandInterface
             );
         }
         $path = array_pop($arguments);
-        $keys = $arguments;
+        $keys = array_shift($arguments);
         return new self(
             $keys,
             new Path($path)


### PR DESCRIPTION
There is an issue on the MultipleGet command class, we have to shift the arguments by one up the same way we pop the path argument .. 